### PR TITLE
Add compatibility wrappers for memory helpers

### DIFF
--- a/ac_utils.py
+++ b/ac_utils.py
@@ -195,3 +195,15 @@ def create_remaining_features(*args, **kwargs):
     from features import create_remaining_features as _crmf
     return _crmf(*args, **kwargs)
 
+
+def reduce_mem_usage(*args, **kwargs):
+    """Compatibility wrapper for :func:`memory.reduce_mem_usage`."""
+    from memory import reduce_mem_usage as _rm
+    return _rm(*args, **kwargs)
+
+
+def log_mem_usage(*args, **kwargs):
+    """Compatibility wrapper for :func:`memory.log_mem_usage`."""
+    from memory import log_mem_usage as _lm
+    return _lm(*args, **kwargs)
+

--- a/test_utils.py
+++ b/test_utils.py
@@ -121,3 +121,10 @@ def test_create_initial_datetime_features_normalises_offsets():
     out = features.create_initial_datetime_features(df.copy())
     ts = out.loc[0, "legs0_departureAt"]
     assert ts.utcoffset().total_seconds() == 5 * 3600
+
+
+def test_reduce_mem_usage_wrapper():
+    df = pd.DataFrame({"a": np.arange(10, dtype=np.int64)})
+    out = utils.reduce_mem_usage(df.copy(), verbose=False)
+    assert out["a"].tolist() == df["a"].tolist()
+    assert out["a"].dtype == np.int8


### PR DESCRIPTION
## Summary
- expose `reduce_mem_usage` and `log_mem_usage` from `ac_utils`
- test wrapper availability

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b958a434833397ab3576eb711684