### PR TITLE
Remove duplicate check_rank_permutation definition

### DIFF
--- a/ac_utils.py
+++ b/ac_utils.py
@@ -146,17 +146,6 @@ def dur_stats(df):
               "| min:", df[col].min(),
               "| max:", df[col].max())
 
-def check_rank_permutation(group):
-    N = len(group)
-    sorted_ranks = sorted(list(group['selected']))
-    expected_ranks = list(range(1, N + 1))
-    if sorted_ranks != expected_ranks:
-        print(f"Invalid rank permutation for ranker_id: {group['ranker_id'].iloc[0]}")
-        print(f"Expected: {expected_ranks}, Got: {sorted_ranks}")
-        return False
-    return True
-
-
 def readme() -> str:
     """Return a short description of this project's purpose.
 


### PR DESCRIPTION
## Summary
- deduplicate `check_rank_permutation` and keep it in `metrics.py`
- remove outdated copy from `ac_utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9d2936708333ba99df59694a5437